### PR TITLE
fix: improve changelog file generation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ serde_json = { version = "1.0.56", features = ["preserve_order"] }
 semver = "0.10.0"
 structopt = { version = "0.3", default-features = false }
 chrono = "0.4.19"
-tokio = {"version"= "0.2.22", features=["rt-threaded", "macros"]}
+tokio = { version = "0.2.22", features = ["rt-threaded", "macros"] }
 eyre = "0.6.1"
 log = "0.4.11"
 env_logger = "0.7.1"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Currently supports only versions from `package.json`.
 
 Example
 
-```sh
+```txt
 λ git-releaser minor
 [INFO] 📝 Current version is 0.8.1-0
 [INFO] 📎 Generating a changelog for v0.9.0
@@ -30,11 +30,11 @@ Example
 
 ## TODO
 
-- [ ] Make the CHANGELOG creation and addition better
-- [ ] Support Cargo.toml
-- [ ] Create a Github release with the new changelog
-- [ ] Signed commits
-- [ ] Improve error handling
-- [ ] Unit test all the things
-- [ ] Read PR information for the repo instead of just git commits
-- [ ] Prompt to stash local changes so the working dir is clean during the release process
+- Support Cargo.toml
+- Create a Github release with the new changelog
+- Signed commits
+- Improve error handling
+- Unit test all the things
+- Read PR information for the repo instead of just git commits
+- Prompt to stash local changes so the working dir is clean during the release process
+- Add confirmation on the release that will be created

--- a/src/commit.rs
+++ b/src/commit.rs
@@ -21,7 +21,6 @@ pub struct Commit {
 
 impl Commit {
     pub fn compact(&self) -> String {
-        // format!("{} [{}]", self.subject, self.author.name)
         self.subject.to_string()
     }
 }
@@ -32,7 +31,7 @@ impl<T: AsRef<str>> From<T> for Commit {
         match serde_json::from_str(input.as_ref()) {
             Ok(commit) => commit,
             Err(err) => {
-                warn!("{:?}", err.to_string());
+                warn!("{}", err.to_string());
                 Commit::default()
             }
         }


### PR DESCRIPTION
Improves it a little bit, I set the constraint that it had to have `# CHANGELOG` at the top, if the file contains something else, it has to be changed for this