### PR TITLE
refactor: improve error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,12 @@ Example
 ```txt
 λ git-releaser minor
 [INFO] 📝 Current version is 0.8.1-0
-[INFO] 📎 Generating a changelog for v0.9.0
+[INFO] 📎 Generating a changelog for 0.9.0
+[INFO] ☁️ Pushing updates
 [INFO] 📖 Here are the changes for 0.9.0:
  - feat: added a new feature
  - fix: fixed pesky bugs
-[INFO] 🚀 v0.9.0 has shipped!
+[INFO] 🚀 0.9.0 has shipped!
 ```
 
 ## TODO
@@ -33,7 +34,6 @@ Example
 - Support Cargo.toml
 - Create a Github release with the new changelog
 - Signed commits
-- Improve error handling
 - Unit test all the things
 - Read PR information for the repo instead of just git commits
 - Prompt to stash local changes so the working dir is clean during the release process

--- a/src/git.rs
+++ b/src/git.rs
@@ -58,8 +58,8 @@ pub fn commits_in_log(args: &[String]) -> Result<Vec<Commit>> {
                 // - `docs: updating changelog`
 
                 let subj = commit.subject.to_string();
-                if subj.starts_with("chore: releasing v")
-                    || subj.starts_with("chore: beginning development on v")
+                if subj.starts_with("chore: releasing")
+                    || subj.starts_with("chore: beginning development on")
                     || subj.starts_with("docs: updating changelog")
                 {
                     return false;
@@ -75,7 +75,7 @@ fn last_tags(n: i32) -> Result<Vec<String>> {
     git(&[
         "for-each-ref",
         &format!("--count={}", n),
-        "--sort=-taggerdate",
+        "--sort=-committerdate",
         "--format=%(refname:short)",
         "refs/tags/*",
     ])
@@ -124,7 +124,10 @@ pub fn push_tag(tag_ver: &str) -> Result<Output> {
 /// Run a git command with arguments.
 fn git(args: &[&str]) -> Result<Output> {
     debug!("git {}", args.join(" "));
-    let output = Command::new("git").args(args).output().unwrap();
+    let output = Command::new("git")
+        .args(args)
+        .output()
+        .map_err(|e| eyre!(e.to_string()))?;
     if output.status.success() {
         Ok(output)
     } else {


### PR DESCRIPTION
This PR also fixes a bug where tags were not sorted correctly after reaching 10 or higher in any of the version types. `0.9.0` was coming up above `0.10.0` for example.

Also decided to drop the `v` prefixes for the versions.