### PR TITLE
feat: toml support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,6 +161,7 @@ dependencies = [
  "serde_json",
  "structopt",
  "tokio",
+ "toml",
 ]
 
 [[package]]
@@ -583,6 +584,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a"
+dependencies = [
+ "indexmap",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0.58", features = ["preserve_order"] }
+toml = { version = "0.5.6", features = ["preserve_order"] }
 semver = "0.11.0"
 structopt = { version = "0.3", default-features = false }
 chrono = "0.4.19"

--- a/README.md
+++ b/README.md
@@ -8,18 +8,18 @@
 
 A CLI tool to that creates a git tag, a changelog and a git release, all in one command.
 
-Currently supports only versions from `package.json`.
+Supports TOML and JSON version files.
 
 ## Usage
 
 ```sh
-[RUST_LOG="debug"] cargo run {patch, minor, major}
+[RUST_LOG="debug"] cargo run {patch, minor, major} [package.json|Cargo.toml]
 ```
 
 Example
 
 ```txt
-λ git-releaser minor
+λ git-releaser minor Cargo.toml
 [INFO] 📝 Current version is 0.8.1-0
 [INFO] 📎 Generating a changelog for 0.9.0
 [INFO] 📡 Pushing updates
@@ -31,7 +31,6 @@ Example
 
 ## TODO
 
-- Support Cargo.toml
 - Create a Github release with the new changelog
 - Unit test all the things
 - Read PR information for the repo instead of just git commits

--- a/src/git.rs
+++ b/src/git.rs
@@ -85,9 +85,9 @@ fn last_tags(n: i32) -> Result<Vec<String>> {
 }
 
 /// Stages the specified files.
-pub fn add_files(files: &[&str]) -> Result<Output> {
-    let files_to_add = files.join(" ");
-    let add_args = vec!["add", files_to_add.as_ref()];
+pub fn add_files(files: Vec<String>) -> Result<Output> {
+    let mut add_args = vec!["add"];
+    files.iter().for_each(|file| add_args.push(file.as_ref()));
     git(&add_args)
 }
 


### PR DESCRIPTION
This PR adds support for versioning via TOML files.

Had to do some weird stuff to sync the lock file as it is better to keep them in sync, otherwise, it will update next time a cargo command is run, leaving you with dangling changes due to the version number. I added a note with it so I can address it when I find a better way.