### PR TITLE
refactor: abstract version file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,7 +150,7 @@ dependencies = [
 
 [[package]]
 name = "git-releaser"
-version = "0.1.0"
+version = "0.0.1-0"
 dependencies = [
  "chrono",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-releaser"
-version = "0.1.0"
+version = "0.0.1-0"
 authors = ["Egill Sveinbjörnsson <egillsveinbjorns@gmail.com>"]
 edition = "2018"
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ Example
 
 - Support Cargo.toml
 - Create a Github release with the new changelog
-- Signed commits
 - Unit test all the things
 - Read PR information for the repo instead of just git commits
 - Prompt to stash local changes so the working dir is clean during the release process

--- a/src/git.rs
+++ b/src/git.rs
@@ -70,11 +70,13 @@ pub fn commits_in_log(args: &[String]) -> Result<Vec<Commit>> {
     })
 }
 
+// https://stackoverflow.com/questions/18659959/git-tag-sorted-in-chronological-order-of-the-date-of-the-commit-pointed-to/57901182#comment75323431_36636526
 /// Get the last n tags
 fn last_tags(n: i32) -> Result<Vec<String>> {
     git(&[
         "for-each-ref",
         &format!("--count={}", n),
+        // "--sort=-taggerdate",
         "--sort=-committerdate",
         "--format=%(refname:short)",
         "refs/tags/*",

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,36 +9,27 @@ mod changelog_gen;
 mod commit;
 mod git;
 mod update_version;
+mod version_file;
 
+use crate::changelog_gen::ChangelogGenerator;
 use crate::git::in_git_repository;
-use crate::update_version::{map_version_type, VersionType};
+use crate::update_version::{map_version_type, update_version, VersionType};
+use crate::version_file::VersionFile;
 use env_logger::Env;
-use eyre::{Result, WrapErr};
-use serde_json::Value;
-use std::fs;
+use eyre::Result;
 use std::io::Write;
 use structopt::StructOpt;
 
 #[derive(StructOpt)]
 struct CliArgs {
     version_type: String,
-    // version_file: String, // package.json, Cargo.toml
+    // version_file: String, // list supported version files in help
 }
 
 // REF https://github.com/github-changelog-generator/github-changelog-generator
-// REF https://docs.rs/git2/0.13.8/git2/struct.Repository.html
 
 // Could probably have a config for main branch and stuff
-
-pub fn read_ver_file(file_path: &str) -> Result<String> {
-    let ver_file = fs::read_to_string(file_path).wrap_err("Could not read version file")?;
-    let v: Value = serde_json::from_str(&ver_file).wrap_err("Could not parse version file")?;
-
-    match v["version"].as_str() {
-        Some(ver) => Ok(ver.to_string()),
-        None => panic!("Version property is not valid"),
-    }
-}
+static MAIN_BRANCH: &str = "main";
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -54,52 +45,49 @@ async fn main() -> Result<()> {
 
     in_git_repository()?;
 
-    let main_branch = "main";
-    let version_type = map_version_type(&version_type);
+    let version_file = "package.json".to_string();
 
-    let change_gen = changelog_gen::ChangelogGenerator {};
+    let version_type = map_version_type(&version_type);
+    let change_gen = ChangelogGenerator::new();
 
     // git::ensure_no_changes();
 
-    // info!("⚠️  Disabling status checks on the main branch");
-
-    let file_path = "package.json";
-
-    // TODO(egilsster): Support reading Cargo.toml
+    let mut version_file = VersionFile::new(version_file)?;
+    let version_file_filename = &version_file.filename.to_owned();
 
     // 1. Get current version value
-    let current_ver = &read_ver_file(file_path)?;
+    let current_ver = version_file.get_version_value();
     info!("📝 Current version is {}", current_ver);
-    let new_ver = &update_version::update_version(current_ver, version_type);
 
     // 2. Get the new version value
-    update_version::update_version_file(file_path, new_ver)?;
+    let new_ver = &update_version(current_ver.to_owned(), version_type)?;
+
+    version_file.update_version_file(new_ver)?;
+
     // 3. Commit version file change and push that plus the new tag
-    git::add_files(&["package.json"])?;
+    git::add_files(&[version_file_filename])?;
     git::commit(&format!("chore: releasing {}", new_ver))?;
 
     // 4. Generate a changelog, stage the CHANGELOG.md, commit that and push
-    let changelog = change_gen.generate_changelog(main_branch, new_ver).await?;
-    git::tag(new_ver)?; // tagged commit, new version is name and version
+    let changelog = change_gen.generate_changelog(MAIN_BRANCH, new_ver).await?;
+    git::tag(&new_ver.to_string())?; // tagged commit, new version is name and version
     git::add_files(&["CHANGELOG.md"])?;
     git::commit("docs: updating changelog [ci skip]")?;
 
     // 5. Bump the working release number to prerelease
-    let current_ver = &read_ver_file(file_path)?;
-    let pre_ver = &update_version::update_version(current_ver, VersionType::Prerelease);
-    update_version::update_version_file(file_path, pre_ver)?;
+    let current_ver = version_file.get_version_value();
+    let pre_ver = &update_version(current_ver.to_owned(), VersionType::Prerelease)?;
+    version_file.update_version_file(pre_ver)?;
 
     // 6. Commit and push updated package.json file
-    git::add_files(&["package.json"])?;
+    git::add_files(&[version_file_filename])?;
     git::commit(&format!(
         "chore: beginning development on {} [ci skip]",
         pre_ver
     ))?;
     info!("📡 Pushing updates");
-    git::push(main_branch)?;
-    git::push_tag(new_ver)?;
-
-    // info!("✅ Enabling status checks on the main branch");
+    git::push(MAIN_BRANCH)?;
+    git::push_tag(&new_ver.to_string())?;
 
     info!(
         "📖 Here are the changes for {}:\n{}",

--- a/src/update_version.rs
+++ b/src/update_version.rs
@@ -1,7 +1,5 @@
-use eyre::{Result, WrapErr};
+use eyre::Result;
 use semver::Version;
-use serde_json::Value;
-use std::fs;
 
 pub enum VersionType {
     Prerelease,
@@ -25,132 +23,88 @@ pub fn map_version_type(version_type_str: &str) -> VersionType {
 /// ## Example
 ///
 /// ```
-/// let res = update_version("0.1.2", VersionType::Prerelease);
-/// assert_eq!(res, "0.1.3-0");
+/// let res = update_version(Version::parse("0.1.2").unwrap(), VersionType::Prerelease).unwrap();
+/// assert_eq!(res.to_string(), "0.1.3-0");
 ///
-/// let res = update_version("0.1.2", VersionType::Patch);
-/// assert_eq!(res, "0.1.3");
+/// let res = update_version(Version::parse("0.1.2").unwrap(), VersionType::Patch).unwrap();
+/// assert_eq!(res.to_string(), "0.1.3");
 ///
-/// let res = update_version("0.1.2", VersionType::Minor);
-/// assert_eq!(res, "0.2.0");
+/// let res = update_version(Version::parse("0.1.2").unwrap(), VersionType::Minor).unwrap();
+/// assert_eq!(res.to_string(), "0.2.0");
 ///
-/// let res = update_version("0.1.2", VersionType::Major);
-/// assert_eq!(res, "1.0.0");
+/// let res = update_version(Version::parse("0.1.2").unwrap(), VersionType::Major).unwrap();
+/// assert_eq!(res.to_string(), "1.0.0");
 /// ```
-pub fn update_version(version: &str, version_type: VersionType) -> String {
-    let mut parsed = Version::parse(version).unwrap();
-
+pub fn update_version(mut version: Version, version_type: VersionType) -> Result<Version> {
     match version_type {
         VersionType::Prerelease => {
             debug!("Prerelease");
-            parsed.patch += 1;
-            parsed.pre = vec![semver::Identifier::Numeric(0)];
+            version.patch += 1;
+            version.pre = vec![semver::Identifier::Numeric(0)];
         }
         VersionType::Patch => {
             debug!("Patch");
-            if !parsed.is_prerelease() {
-                parsed.patch += 1;
+            if !version.is_prerelease() {
+                version.patch += 1;
             }
-            parsed.pre = vec![];
+            version.pre = vec![];
         }
         VersionType::Minor => {
             debug!("Minor");
-            parsed.minor += 1;
-            parsed.patch = 0;
-            parsed.pre = vec![];
+            version.minor += 1;
+            version.patch = 0;
+            version.pre = vec![];
         }
         VersionType::Major => {
             debug!("Major");
-            parsed.major += 1;
-            parsed.minor = 0;
-            parsed.patch = 0;
-            parsed.pre = vec![];
+            version.major += 1;
+            version.minor = 0;
+            version.patch = 0;
+            version.pre = vec![];
         }
     }
-    parsed.to_string()
-}
-
-/// Updates the version file with the new version value
-pub fn update_version_file(file_path: &str, new_ver: &str) -> Result<()> {
-    let ver_file = fs::read_to_string(file_path).wrap_err("Could not read version file")?;
-    let mut v: Value = serde_json::from_str(&ver_file).wrap_err("Could not parse version file")?;
-
-    v["version"] = serde_json::to_value(&new_ver).map_err(|e| eyre!(e.to_string()))?;
-
-    let version_file_contents =
-        serde_json::to_string_pretty(&v).map_err(|e| eyre!(e.to_string()))?;
-
-    debug!("📝 New version is {}", new_ver);
-    fs::write(file_path, format!("{}\n", version_file_contents))
-        .wrap_err("Could not write new version file")?;
-
-    Ok(())
+    Ok(version)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    fn to_version(version: &str) -> Version {
+        Version::parse(version).unwrap()
+    }
+
     #[test]
     fn test_update_version_prerelease() {
-        let res = update_version("0.1.2", VersionType::Prerelease);
-        assert_eq!(res, "0.1.3-0");
+        let res = update_version(to_version("0.1.2"), VersionType::Prerelease).unwrap();
+        assert_eq!(res.to_string(), "0.1.3-0");
     }
 
     #[test]
     fn test_update_version_patch() {
-        let res = update_version("0.1.2", VersionType::Patch);
-        assert_eq!(res, "0.1.3");
-        let res = update_version("0.1.2-0", VersionType::Patch);
-        assert_eq!(res, "0.1.2");
+        let res = update_version(to_version("0.1.2"), VersionType::Patch).unwrap();
+        assert_eq!(res.to_string(), "0.1.3");
+        let res = update_version(to_version("0.1.2-0"), VersionType::Patch).unwrap();
+        assert_eq!(res.to_string(), "0.1.2");
     }
 
     #[test]
     fn test_update_version_minor() {
-        let res = update_version("0.1.2", VersionType::Minor);
-        assert_eq!(res, "0.2.0");
-        let res = update_version("0.1.2-0", VersionType::Minor);
-        assert_eq!(res, "0.2.0");
-        let res = update_version("0.2.1-0", VersionType::Minor);
-        assert_eq!(res, "0.3.0");
+        let res = update_version(to_version("0.1.2"), VersionType::Minor).unwrap();
+        assert_eq!(res.to_string(), "0.2.0");
+        let res = update_version(to_version("0.1.2-0"), VersionType::Minor).unwrap();
+        assert_eq!(res.to_string(), "0.2.0");
+        let res = update_version(to_version("0.2.1-0"), VersionType::Minor).unwrap();
+        assert_eq!(res.to_string(), "0.3.0");
     }
 
     #[test]
     fn test_update_version_major() {
-        let res = update_version("0.1.2", VersionType::Major);
-        assert_eq!(res, "1.0.0");
-        let res = update_version("0.1.0-0", VersionType::Major);
-        assert_eq!(res, "1.0.0");
-        let res = update_version("1.0.1-0", VersionType::Major);
-        assert_eq!(res, "2.0.0");
-    }
-
-    #[test]
-    fn test_prerelease_version_and_preserve_structure() {
-        let test_file = "test.json";
-        let contents = r#"
-            {
-                "name": "testing",
-                "version": "0.2.5",
-                "author": "me"
-            }
-        "#
-        .to_owned();
-        let _ = fs::write(test_file, contents).unwrap();
-
-        update_version_file(test_file, "0.2.6").unwrap();
-
-        let updated_contents = fs::read_to_string(test_file).unwrap();
-        fs::remove_file(test_file).unwrap();
-
-        assert_eq!(
-            updated_contents,
-            r#"{
-  "name": "testing",
-  "version": "0.2.6",
-  "author": "me"
-}
-"#
-        );
+        let res = update_version(to_version("0.1.2"), VersionType::Major).unwrap();
+        assert_eq!(res.to_string(), "1.0.0");
+        let res = update_version(to_version("0.1.0-0"), VersionType::Major).unwrap();
+        assert_eq!(res.to_string(), "1.0.0");
+        let res = update_version(to_version("1.0.1-0"), VersionType::Major).unwrap();
+        assert_eq!(res.to_string(), "2.0.0");
     }
 }

--- a/src/version_file.rs
+++ b/src/version_file.rs
@@ -1,0 +1,154 @@
+use eyre::{Result, WrapErr};
+use semver::Version;
+use std::fs;
+
+pub enum VersionFiletype {
+    JSON,
+}
+
+impl VersionFiletype {
+    pub fn from_str(filename: &str) -> Result<Self> {
+        let filename_lower = filename.to_lowercase();
+        let file_ext = filename_lower.split('.').last().unwrap();
+        match file_ext {
+            "json" => Ok(VersionFiletype::JSON),
+            _ => Err(eyre!("Extension not supported")),
+        }
+    }
+}
+
+trait ToVersion {
+    fn to_version(&self) -> Result<Version>;
+}
+
+impl ToVersion for str {
+    fn to_version(&self) -> Result<Version> {
+        Version::parse(self).wrap_err("Invalid version")
+    }
+}
+
+pub struct VersionFile {
+    pub filename: String,
+    pub version_value: Version,
+    pub version_filetype: VersionFiletype,
+}
+
+impl VersionFile {
+    pub fn new(filename: String) -> Result<Self> {
+        if !is_version_file_supported(&filename) {
+            return Err(eyre!("The specified version file is not supported"));
+        }
+
+        let version_filetype = VersionFiletype::from_str(&filename)?;
+        let version_value = read_version_file(&version_filetype, &filename)?;
+
+        Ok(VersionFile {
+            filename,
+            version_value,
+            version_filetype,
+        })
+    }
+
+    /// Updates the version file with the new version value
+    pub fn update_version_file(&mut self, new_ver: &Version) -> Result<()> {
+        let ver_file = fs::read_to_string(&self.filename)?;
+
+        match self.version_filetype {
+            VersionFiletype::JSON => {
+                let mut v: serde_json::Value = serde_json::from_str(&ver_file)?;
+                v["version"] = serde_json::to_value(&new_ver.to_string())?;
+
+                let version_file_contents = format!("{}\n", serde_json::to_string_pretty(&v)?);
+                fs::write(&self.filename, version_file_contents)?;
+            }
+        };
+
+        debug!("📝 New version is {}", new_ver);
+
+        self.version_value = new_ver.to_owned();
+
+        Ok(())
+    }
+
+    pub fn get_version_value(&self) -> &Version {
+        &self.version_value
+    }
+}
+
+pub fn read_version_file(version_filetype: &VersionFiletype, file_path: &str) -> Result<Version> {
+    match version_filetype {
+        VersionFiletype::JSON => {
+            let ver_file =
+                fs::read_to_string(file_path).wrap_err("Could not read JSON version file")?;
+            let v: serde_json::Value =
+                serde_json::from_str(&ver_file).wrap_err("Could not parse JSON file")?;
+
+            match v.get("version") {
+                Some(ver) => ver.as_str().unwrap().to_version(),
+                None => panic!("Version property is not valid"),
+            }
+        }
+    }
+}
+
+/// Returns true if the version file is supported
+/// and false otherwise.
+fn is_version_file_supported(version_file: &str) -> bool {
+    version_file.ends_with(".toml") || version_file.ends_with(".json")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_update_version_file_package_json() {
+        let test_file = "test.json";
+        let contents = r#"
+            {
+                "name": "testing",
+                "version": "0.2.5",
+                "author": "me"
+            }
+        "#
+        .to_owned();
+
+        fs::write(test_file, contents).unwrap();
+
+        let mut v = VersionFile::new(test_file.to_owned()).unwrap();
+
+        v.update_version_file(&Version::parse("0.2.6").unwrap())
+            .unwrap();
+
+        let updated_contents = fs::read_to_string(&test_file).unwrap();
+        fs::remove_file(&test_file).unwrap();
+
+        assert_eq!(v.get_version_value().to_string(), "0.2.6");
+        assert_eq!(
+            updated_contents,
+            r#"{
+  "name": "testing",
+  "version": "0.2.6",
+  "author": "me"
+}
+"#
+        );
+    }
+
+    #[test]
+    fn test_is_version_file_supported() {
+        assert!(is_version_file_supported("Cargo.toml") == true);
+        assert!(is_version_file_supported("Cargo_test.toml") == true);
+        assert!(is_version_file_supported("package.json") == true);
+        assert!(is_version_file_supported("version.json") == true);
+        assert!(is_version_file_supported("version.txt") == false);
+        assert!(is_version_file_supported("foo") == false);
+    }
+
+    #[test]
+    fn test_str_to_version() {
+        let ver = "0.1.2";
+        let res = ver.to_version().unwrap();
+        assert_eq!(res.to_string(), ver);
+    }
+}


### PR DESCRIPTION
This PR is to prepare for TOML support. It abstracts the version file logic and makes it more extendable.

This PR also improves/cleans up error handling as well as switches from `&str` for the version value to `semver::Version`.