### PR TITLE
feat: improve cli usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,18 @@ Supports TOML and JSON version files.
 ## Usage
 
 ```sh
-[RUST_LOG="debug"] cargo run {patch, minor, major} [package.json|Cargo.toml]
+git-releaser -t [patch|minor|major] -f [package.json|Cargo.toml] --main-branch main [--log-level debug]
 ```
 
 Example
+
+```sh
+git-releaser -t minor -f package.json -b main
+```
+
+See `git-releaser --help` for more information on usage.
+
+### Example
 
 ```txt
 λ git-releaser minor Cargo.toml


### PR DESCRIPTION
```txt
λ target/release/git-releaser --help
git-releaser 0.0.1-0

git-releaser -t [major|minor|patch] -f package.json -b main

USAGE:
    git-releaser [OPTIONS] --main-branch <main-branch> --file <version-file> --type <version-type>

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
    -l, --log-level <log-level>         [default: info]
    -b, --main-branch <main-branch>    
    -f, --file <version-file>          
    -t, --type <version-type>   
```